### PR TITLE
[BUGFIX] modestbranding overwrites relatedVideos

### DIFF
--- a/Configuration/TypoScript/ContentElement/constants.typoscript
+++ b/Configuration/TypoScript/ContentElement/constants.typoscript
@@ -66,7 +66,7 @@ plugin.bootstrap_package_contentelements {
             showinfo = 0
             # cat=bootstrap package: content elements/131_contentelement/005_relatedVideos; type=boolean; label=Related Videos
             relatedVideos = 0
-            # cat=bootstrap package: content elements/131_contentelement/005_relatedVideos; type=boolean; label=Modest Branding
+            # cat=bootstrap package: content elements/131_contentelement/005_modestbranding; type=boolean; label=Modest Branding
             modestbranding = 0
         }
     }


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

relatedVideos = 0 and modestbranding = 0 are different constants but line 69 overwrites 67 
There is no section content elements/media/relatedVideos in the constant editor.

## Steps to Validate

1. compare line 69 and 67